### PR TITLE
fix: update base image

### DIFF
--- a/period_predictor/Dockerfile
+++ b/period_predictor/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base-python:3.11-alpine3.18
 FROM ${BUILD_FROM}
 
 WORKDIR /app

--- a/period_predictor/build.json
+++ b/period_predictor/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.11",
-    "amd64": "ghcr.io/home-assistant/amd64-base-python:3.11",
-    "armv7": "ghcr.io/home-assistant/armv7-base-python:3.11",
-    "armhf": "ghcr.io/home-assistant/armhf-base-python:3.11",
-    "i386": "ghcr.io/home-assistant/i386-base-python:3.11"
+    "aarch64": "ghcr.io/home-assistant/aarch64-base-python:3.11-alpine3.18",
+    "amd64": "ghcr.io/home-assistant/amd64-base-python:3.11-alpine3.18",
+    "armv7": "ghcr.io/home-assistant/armv7-base-python:3.11-alpine3.18",
+    "armhf": "ghcr.io/home-assistant/armhf-base-python:3.11-alpine3.18",
+    "i386": "ghcr.io/home-assistant/i386-base-python:3.11-alpine3.18"
   }
 }


### PR DESCRIPTION
## Summary
- update Dockerfile to set default base image
- specify current base images for all architectures

## Testing
- `python3 -m py_compile period_predictor/server.py`
- `docker build period_predictor -t test-period_predictor:latest` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68b87952128c8325bcb7c8753420edfd