### PR TITLE
fix: use s6 service for container startup

### DIFF
--- a/period_predictor/Dockerfile
+++ b/period_predictor/Dockerfile
@@ -8,6 +8,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY server.py ./
 COPY web /web
+COPY rootfs /
 
 EXPOSE 80
-CMD ["python3", "/app/server.py"]

--- a/period_predictor/rootfs/etc/services.d/period-predictor/run
+++ b/period_predictor/rootfs/etc/services.d/period-predictor/run
@@ -1,0 +1,5 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+
+bashio::log.info "Starting Period Predictor service"
+exec python3 /app/server.py


### PR DESCRIPTION
## Summary
- start Period Predictor via s6 service script
- copy rootfs into image and remove CMD so s6 runs as PID 1

## Testing
- `python -m py_compile period_predictor/server.py`
- `shellcheck period_predictor/rootfs/etc/services.d/period-predictor/run`


------
https://chatgpt.com/codex/tasks/task_e_68b87af19c908325969ec87e32145b9f