### PR TITLE
fix: use s6 service for container startup

### DIFF
--- a/period_predictor/Dockerfile
+++ b/period_predictor/Dockerfile
@@ -8,6 +8,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY server.py ./
 COPY web /web
+COPY rootfs /
 
 EXPOSE 80
-CMD ["python3", "/app/server.py"]

--- a/period_predictor/config.yaml
+++ b/period_predictor/config.yaml
@@ -1,5 +1,5 @@
 name: Period Predictor
-version: "0.1.0"
+version: "0.1.1"
 slug: period_predictor
 description: Record period start dates and predict the next period using a simple statistical model.
 arch:
@@ -14,5 +14,6 @@ panel_title: Period Predictor
 panel_icon: mdi:calendar
 startup: application
 boot: auto
+init: false
 map:
   - data:rw

--- a/period_predictor/rootfs/etc/services.d/period-predictor/run
+++ b/period_predictor/rootfs/etc/services.d/period-predictor/run
@@ -1,0 +1,5 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+
+bashio::log.info "Starting Period Predictor service"
+exec python3 /app/server.py


### PR DESCRIPTION
## Summary
- start Period Predictor via s6 service script
- copy rootfs into image and remove CMD so s6 runs as PID 1
- disable Docker init to keep s6 as PID 1

## Testing
- `python -m py_compile period_predictor/server.py`
- `shellcheck period_predictor/rootfs/etc/services.d/period-predictor/run`


------
https://chatgpt.com/codex/tasks/task_e_68b87af19c908325969ec87e32145b9f