### PR TITLE
Build and serve compiled web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/period_predictor/Dockerfile
+++ b/period_predictor/Dockerfile
@@ -8,7 +8,8 @@ WORKDIR /app
 COPY backend /app/backend
 COPY web /app/web
 RUN npm --prefix backend install \
-    && npm --prefix web install
+    && npm --prefix web install \
+    && npm --prefix web run build
 
 COPY rootfs /
 

--- a/period_predictor/backend/index.js
+++ b/period_predictor/backend/index.js
@@ -7,7 +7,7 @@ const PORT = process.env.PORT || 3002;
 const DB_PATH = path.join('/data', 'periods.db');
 
 app.use(express.json());
-app.use(express.static(path.join(__dirname, '../web')));
+app.use(express.static(path.join(__dirname, '../web/dist')));
 
 // Initialize database and ensure table exists
 const db = new sqlite3.Database(DB_PATH);

--- a/period_predictor/web/package.json
+++ b/period_predictor/web/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "build": "vite build",
     "test": "echo \"No tests\""
   },
   "dependencies": {
@@ -10,5 +11,9 @@
     "@fullcalendar/core": "^6.1.7",
     "@fullcalendar/daygrid": "^6.1.7",
     "@fullcalendar/vue3": "^6.1.7"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^5.0.0"
   }
 }

--- a/period_predictor/web/vite.config.js
+++ b/period_predictor/web/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
## Summary
- build frontend with Vite and add build script
- serve compiled assets from Express backend
- run web build during Docker image creation

## Testing
- `npm run build --prefix period_predictor/web`
- `npm test --prefix period_predictor/web`
- `npm test --prefix period_predictor/backend`


------
https://chatgpt.com/codex/tasks/task_e_68b87ecfdc288325ae15caee9cff35f7