### PR TITLE
feat: add configurable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repository contains a Home Assistant add-on that lets you record period sta
 
 The backend now runs on [Express](https://expressjs.com/) with a small Vue-based frontend, listening on port **3002** by default.
 
+## Logging
+
+Logs from the add-on appear in Home Assistant's add-on log panel. Set the verbosity by adjusting the `log_level` option in the add-on configuration (`debug`, `info`, `warning`, or `error`).
+
 ## Add this repository to Home Assistant
 
 1. Go to **Settings → Add-ons → Add-on Store**.

--- a/period_predictor/backend/index.js
+++ b/period_predictor/backend/index.js
@@ -2,24 +2,23 @@ const path = require('path');
 const fs = require('fs');
 const express = require('express');
 const sqlite3 = require('sqlite3').verbose();
+const logger = require('./logger');
 
 const app = express();
 const PORT = process.env.PORT || 3002;
 
-const logError = (...args) => console.log('[ERROR]', ...args);
-
 process.on('uncaughtException', (err) => {
-  logError('Uncaught exception:', err);
+  logger.error('Uncaught exception:', err);
 });
 
 process.on('unhandledRejection', (err) => {
-  logError('Unhandled promise rejection:', err);
+  logger.error('Unhandled promise rejection:', err);
 });
 
-// Determine a writable location for the database.  In the Home Assistant
+// Determine a writable location for the database. In the Home Assistant
 // environment the "/data" directory is used for persistence, but in other
 // environments (such as local development or tests) that directory may not
-// exist.  Fall back to a local "data" folder inside the project if needed.
+// exist. Fall back to a local "data" folder inside the project if needed.
 const DATA_DIR = '/data';
 let dbPathDir = DATA_DIR;
 try {
@@ -29,20 +28,29 @@ try {
   fs.mkdirSync(dbPathDir, { recursive: true });
 }
 const DB_PATH = path.join(dbPathDir, 'periods.db');
+logger.info(`Using database at ${DB_PATH}`);
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname, '../web/dist')));
+app.use((req, _res, next) => {
+  logger.debug(`${req.method} ${req.url}`);
+  next();
+});
 
 // Initialize database and ensure table exists
 const db = new sqlite3.Database(DB_PATH, (err) => {
   if (err) {
-    logError('Failed to open database:', err);
+    logger.error('Failed to open database:', err);
+  } else {
+    logger.info('Opened database successfully');
   }
 });
 db.serialize(() => {
   db.run('CREATE TABLE IF NOT EXISTS periods (start_date TEXT)', (err) => {
     if (err) {
-      logError('Failed to create periods table:', err);
+      logger.error('Failed to create periods table:', err);
+    } else {
+      logger.debug('Ensured periods table exists');
     }
   });
 });
@@ -52,23 +60,25 @@ app.route('/api/periods')
   .get((req, res) => {
     db.all('SELECT start_date FROM periods ORDER BY start_date', (err, rows) => {
       if (err) {
-        logError('Failed to fetch periods:', err);
+        logger.error('Failed to fetch periods:', err);
         return res.status(500).json({ error: err.message });
       }
+      logger.debug(`Returning ${rows.length} periods`);
       res.json(rows.map(r => r.start_date));
     });
   })
   .post((req, res) => {
     const date = req.body?.date;
     if (!date) {
-      logError('POST /api/periods missing required "date" field');
+      logger.error('POST /api/periods missing required "date" field');
       return res.status(400).json({ error: 'date is required' });
     }
     db.run('INSERT INTO periods (start_date) VALUES (?)', [date], function (err) {
       if (err) {
-        logError('Failed to insert period:', err);
+        logger.error('Failed to insert period:', err);
         return res.status(500).json({ error: err.message });
       }
+      logger.info(`Recorded period start date ${date}`);
       res.status(201).json({});
     });
   });
@@ -77,10 +87,13 @@ app.route('/api/periods')
 app.get('/api/prediction', (req, res) => {
   db.all('SELECT start_date FROM periods ORDER BY start_date', (err, rows) => {
     if (err) {
-      logError('Failed to generate prediction:', err);
+      logger.error('Failed to generate prediction:', err);
       return res.status(500).json({ error: err.message });
     }
-    if (rows.length < 2) return res.json({ next: null });
+    if (rows.length < 2) {
+      logger.info('Not enough data to generate prediction');
+      return res.json({ next: null });
+    }
     const dates = rows.map(r => new Date(r.start_date));
     const intervals = [];
     for (let i = 1; i < dates.length; i++) {
@@ -89,11 +102,13 @@ app.get('/api/prediction', (req, res) => {
     }
     const avg = intervals.reduce((a, b) => a + b, 0) / intervals.length;
     const nextDate = new Date(dates[dates.length - 1].getTime() + avg * 24 * 60 * 60 * 1000);
+    logger.info(`Predicted next period start ${nextDate.toISOString().split('T')[0]}`);
     res.json({ next: nextDate.toISOString().split('T')[0] });
   });
 });
 
 // Start server
 app.listen(PORT, () => {
-  console.log(`Backend server listening on port ${PORT}`);
+  logger.info(`Backend server listening on port ${PORT}`);
 });
+

--- a/period_predictor/backend/logger.js
+++ b/period_predictor/backend/logger.js
@@ -1,0 +1,21 @@
+const levels = ['debug', 'info', 'warning', 'error'];
+const currentLevel = process.env.LOG_LEVEL ? process.env.LOG_LEVEL.toLowerCase() : 'info';
+
+function shouldLog(level) {
+  return levels.indexOf(level) >= levels.indexOf(currentLevel);
+}
+
+module.exports = {
+  debug: (...args) => {
+    if (shouldLog('debug')) console.debug('[DEBUG]', ...args);
+  },
+  info: (...args) => {
+    if (shouldLog('info')) console.log('[INFO]', ...args);
+  },
+  warn: (...args) => {
+    if (shouldLog('warning')) console.warn('[WARN]', ...args);
+  },
+  error: (...args) => {
+    if (shouldLog('error')) console.error('[ERROR]', ...args);
+  },
+};

--- a/period_predictor/config.yaml
+++ b/period_predictor/config.yaml
@@ -17,3 +17,7 @@ boot: auto
 init: false
 map:
   - data:rw
+options:
+  log_level: info
+schema:
+  log_level: list(debug|info|warning|error)

--- a/period_predictor/rootfs/etc/services.d/period-predictor/run
+++ b/period_predictor/rootfs/etc/services.d/period-predictor/run
@@ -14,4 +14,8 @@ fi
 export PORT
 bashio::log.info "Listening on port ${PORT}"
 
+LOG_LEVEL="$(bashio::config 'log_level' 'info')"
+export LOG_LEVEL
+bashio::log.info "Using log level ${LOG_LEVEL}"
+
 exec npm --prefix /app/backend start


### PR DESCRIPTION
## Summary
- add simple logger module with support for debug/info/warning/error levels
- route backend logs through logger for database lifecycle, requests, and predictions
- expose `log_level` configuration and pass it through service start script
- document logging option in README

## Testing
- `npm --prefix period_predictor/backend test`
- `npm --prefix period_predictor/web test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b2ff835083258fca104db31d8d29