### PR TITLE
feat: show calendar above logging buttons

### DIFF
--- a/period_predictor/web/src/components/SidebarCalendar.vue
+++ b/period_predictor/web/src/components/SidebarCalendar.vue
@@ -1,11 +1,13 @@
 <template>
   <aside class="sidebar" tabindex="0">
-    <FullCalendar
-      initialView="dayGridMonth"
-      :plugins="calendarPlugins"
-      :events="events"
-      aria-label="Period calendar"
-    />
+    <div class="calendar" aria-label="Period calendar">
+      <FullCalendar
+        initialView="dayGridMonth"
+        :plugins="calendarPlugins"
+        :events="events"
+        :headerToolbar="toolbarOptions"
+      />
+    </div>
     <div class="controls">
       <button
         @click="startPeriod"
@@ -32,6 +34,11 @@ import dayGridPlugin from '@fullcalendar/daygrid'
 
 const events = ref([])
 const calendarPlugins = [dayGridPlugin]
+const toolbarOptions = {
+  left: 'prev,next',
+  center: 'title',
+  right: ''
+}
 
 async function startPeriod() {
   const today = new Date().toISOString().split('T')[0]

--- a/period_predictor/web/src/styles/sidebar.css
+++ b/period_predictor/web/src/styles/sidebar.css
@@ -6,6 +6,11 @@
   background-color: #f5f5f5;
 }
 
+.calendar {
+  margin-bottom: 1rem;
+  height: 300px;
+}
+
 .controls {
   margin-top: 1rem;
   display: flex;


### PR DESCRIPTION
## Summary
- display calendar above period logging buttons in web UI
- add spacing between calendar and controls
- enable month navigation and ensure calendar container has height

## Testing
- `npm test` (backend)
- `npm test` (web)
- `npm run build` (web)`

------
https://chatgpt.com/codex/tasks/task_e_68b9b74e18a08325b48cd89e19432647