### PR TITLE
Display interactive calendar

### DIFF
--- a/period_predictor/web/src/components/SidebarCalendar.vue
+++ b/period_predictor/web/src/components/SidebarCalendar.vue
@@ -31,6 +31,8 @@
 import { ref, onMounted, onBeforeUnmount } from 'vue'
 import FullCalendar from '@fullcalendar/vue3'
 import dayGridPlugin from '@fullcalendar/daygrid'
+import '@fullcalendar/core/index.css'
+import '@fullcalendar/daygrid/index.css'
 
 const events = ref([])
 const calendarPlugins = [dayGridPlugin]


### PR DESCRIPTION
## Summary
- import FullCalendar core and daygrid styles so the calendar renders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9bb474bb88325b55b36d5ab49a5b5