### PR TITLE
fix: remove broken FullCalendar CSS imports

### DIFF
--- a/period_predictor/web/src/components/SidebarCalendar.vue
+++ b/period_predictor/web/src/components/SidebarCalendar.vue
@@ -31,8 +31,6 @@
 import { ref, onMounted, onBeforeUnmount } from 'vue'
 import FullCalendar from '@fullcalendar/vue3'
 import dayGridPlugin from '@fullcalendar/daygrid'
-import '@fullcalendar/core/index.css'
-import '@fullcalendar/daygrid/index.css'
 
 const events = ref([])
 const calendarPlugins = [dayGridPlugin]


### PR DESCRIPTION
## Summary
- remove invalid FullCalendar CSS imports that caused Vite build failure

## Testing
- `npm --prefix period_predictor/web test`
- `npm --prefix period_predictor/web run build`
- `docker build -t test-addon period_predictor` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bf46ba488325baf5bd4179e3ca74