### PR TITLE
Fix calendar visibility and add logging

### DIFF
--- a/period_predictor/web/src/components/SidebarCalendar.vue
+++ b/period_predictor/web/src/components/SidebarCalendar.vue
@@ -50,14 +50,17 @@ async function startPeriod() {
     })
     if (!res.ok) throw new Error('Request failed')
     events.value = [...events.value, { title: 'Period', start: today }]
+    console.log('Logged period for', today)
     alert('Period logged!')
   } catch (err) {
+    console.error('Failed to log period', err)
     alert('Failed to log period')
   }
 }
 
 async function endPeriod() {
   // Endpoint not yet implemented
+  console.warn('End period action is not implemented')
 }
 
 function handleKey(e) {
@@ -71,9 +74,15 @@ function handleKey(e) {
 
 onMounted(async () => {
   window.addEventListener('keydown', handleKey)
-  const res = await fetch('api/periods')
-  const dates = await res.json()
-  events.value = dates.map((d) => ({ title: 'Period', start: d }))
+  try {
+    const res = await fetch('api/periods')
+    if (!res.ok) throw new Error('Request failed')
+    const dates = await res.json()
+    events.value = dates.map((d) => ({ title: 'Period', start: d }))
+    console.log('Loaded periods', events.value)
+  } catch (err) {
+    console.error('Failed to load periods', err)
+  }
 })
 
 onBeforeUnmount(() => {

--- a/period_predictor/web/src/main.js
+++ b/period_predictor/web/src/main.js
@@ -2,5 +2,6 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import './styles/sidebar.css'
 import './styles/fullcalendar-core.css'
+import '@fullcalendar/daygrid/index.css'
 
 createApp(App).mount('#app')


### PR DESCRIPTION
## Summary
- Ensure FullCalendar's day grid styles load to render the calendar
- Add console logging for period start and load failures to aid debugging

## Testing
- `npm test` (web)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68b9c91fac58832594c6ee8f03ac7768