### PR TITLE
fix: remove daygrid css import

### DIFF
--- a/period_predictor/web/src/main.js
+++ b/period_predictor/web/src/main.js
@@ -2,6 +2,5 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import './styles/sidebar.css'
 import './styles/fullcalendar-core.css'
-import '@fullcalendar/daygrid/index.css'
 
 createApp(App).mount('#app')


### PR DESCRIPTION
## Summary
- remove deprecated @fullcalendar/daygrid CSS import

## Testing
- `npm --prefix period_predictor/web test`
- `npm --prefix period_predictor/web run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9df9830808325ae78bc72ad1b12c6