### PR TITLE
Add period start/end management with context menu

### DIFF
--- a/period_predictor/web/src/components/SidebarCalendar.vue
+++ b/period_predictor/web/src/components/SidebarCalendar.vue
@@ -17,11 +17,11 @@
             <td
               v-for="day in week"
               :key="day.date || wi + '-' + day.text"
-              :class="{ today: day.isToday, period: day.isPeriod, clickable: day.date && !day.isPeriod }"
-              @click="logPeriod(day.date)"
-              @keydown.enter="logPeriod(day.date)"
-              :tabindex="day.date && !day.isPeriod ? 0 : -1"
-              :role="day.date && !day.isPeriod ? 'button' : null"
+              :class="{ today: day.isToday, period: day.isPeriod, clickable: day.date }"
+              @click="openMenu(day.date, $event)"
+              @contextmenu.prevent="openMenu(day.date, $event)"
+              :tabindex="day.date ? 0 : -1"
+              :role="day.date ? 'button' : null"
             >
               {{ day.text }}
             </td>
@@ -30,13 +30,23 @@
       </table>
     </div>
     <div class="controls">
-      <button @click="startPeriod" aria-label="Start period" tabindex="1">
-        I got my period
+      <button @click="clearAll" aria-label="Clear all records" tabindex="1">
+        Clear all records
       </button>
-      <button @click="endPeriod" aria-label="End period" tabindex="2">
-        I have finished my period
+      <button @click="testDb" aria-label="Test database" tabindex="2">
+        Test database
       </button>
     </div>
+    <ul
+      v-if="menu.visible"
+      class="context-menu"
+      :style="{ top: menu.y + 'px', left: menu.x + 'px' }"
+    >
+      <li @click="addStart(menu.date)">Add start period</li>
+      <li @click="removeStart(menu.date)">Remove start period</li>
+      <li @click="addEnd(menu.date)">Add period end</li>
+      <li @click="removeEnd(menu.date)">Remove period end</li>
+    </ul>
   </aside>
 </template>
 
@@ -45,11 +55,26 @@ import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 
 const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 const current = ref(new Date())
-const events = ref([])
+const periods = ref([]) // {start_date, end_date}
+const events = ref([]) // individual dates to mark
+const menu = ref({ visible: false, x: 0, y: 0, date: null })
 
 const monthYear = computed(() =>
   current.value.toLocaleString('default', { month: 'long', year: 'numeric' })
 )
+
+function computeEvents() {
+  const dates = []
+  for (const p of periods.value) {
+    if (!p.end_date) continue
+    const start = new Date(p.start_date)
+    const end = new Date(p.end_date)
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+      dates.push(new Date(d).toISOString().split('T')[0])
+    }
+  }
+  events.value = dates
+}
 
 function buildWeeks() {
   const start = new Date(current.value.getFullYear(), current.value.getMonth(), 1)
@@ -65,8 +90,7 @@ function buildWeeks() {
     const date = new Date(current.value.getFullYear(), current.value.getMonth(), day)
     const dateStr = date.toISOString().split('T')[0]
     const isPeriod = events.value.includes(dateStr)
-    const isToday =
-      dateStr === new Date().toISOString().split('T')[0]
+    const isToday = dateStr === new Date().toISOString().split('T')[0]
     week.push({ text: day, date: dateStr, isToday, isPeriod })
     if (week.length === 7) {
       weeks.push(week)
@@ -102,58 +126,115 @@ function nextMonth() {
   weeks.value = buildWeeks()
 }
 
-async function logPeriod(date) {
-  if (!date || events.value.includes(date)) return
+function openMenu(date, evt) {
+  if (!date) return
+  evt.stopPropagation()
+  menu.value = { visible: true, x: evt.clientX, y: evt.clientY, date }
+}
+
+function closeMenu() {
+  menu.value.visible = false
+}
+
+async function refreshPeriods() {
   try {
-    const res = await fetch('api/periods', {
+    const res = await fetch('api/periods')
+    if (!res.ok) throw new Error('Request failed')
+    periods.value = await res.json()
+    computeEvents()
+    weeks.value = buildWeeks()
+  } catch (err) {
+    console.error('Failed to load periods', err)
+  }
+}
+
+async function addStart(date) {
+  closeMenu()
+  try {
+    const res = await fetch('api/periods/start', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ date })
     })
     if (!res.ok) throw new Error('Request failed')
-    events.value.push(date)
-    weeks.value = buildWeeks()
-    console.log('Logged period for', date)
-    alert('Period logged!')
+    await refreshPeriods()
   } catch (err) {
-    console.error('Failed to log period', err)
-    alert('Failed to log period')
+    console.error('Failed to add start', err)
+    alert('Failed to add start')
   }
 }
 
-async function startPeriod() {
-  const today = new Date().toISOString().split('T')[0]
-  await logPeriod(today)
-}
-
-async function endPeriod() {
-  console.warn('End period action is not implemented')
-}
-
-function handleKey(e) {
-  const key = e.key.toLowerCase()
-  if (key === 's') {
-    startPeriod()
-  } else if (key === 'e') {
-    endPeriod()
+async function removeStart(date) {
+  closeMenu()
+  try {
+    const res = await fetch(`api/periods/start/${date}`, { method: 'DELETE' })
+    if (!res.ok) throw new Error('Request failed')
+    await refreshPeriods()
+  } catch (err) {
+    console.error('Failed to remove start', err)
+    alert('Failed to remove start')
   }
 }
 
-onMounted(async () => {
-  window.addEventListener('keydown', handleKey)
+async function addEnd(date) {
+  closeMenu()
+  try {
+    const res = await fetch('api/periods/end', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ date })
+    })
+    if (!res.ok) throw new Error('Request failed')
+    await refreshPeriods()
+  } catch (err) {
+    console.error('Failed to add end', err)
+    alert('Failed to add end')
+  }
+}
+
+async function removeEnd(date) {
+  closeMenu()
+  try {
+    const res = await fetch(`api/periods/end/${date}`, { method: 'DELETE' })
+    if (!res.ok) throw new Error('Request failed')
+    await refreshPeriods()
+  } catch (err) {
+    console.error('Failed to remove end', err)
+    alert('Failed to remove end')
+  }
+}
+
+async function clearAll() {
+  if (!confirm('Delete all records?')) return
+  try {
+    const res = await fetch('api/periods', { method: 'DELETE' })
+    if (!res.ok) throw new Error('Request failed')
+    await refreshPeriods()
+  } catch (err) {
+    console.error('Failed to clear records', err)
+    alert('Failed to clear records')
+  }
+}
+
+async function testDb() {
   try {
     const res = await fetch('api/periods')
     if (!res.ok) throw new Error('Request failed')
-    events.value = await res.json()
-    weeks.value = buildWeeks()
-    console.log('Loaded periods', events.value)
+    const data = await res.json()
+    alert(JSON.stringify(data))
   } catch (err) {
-    console.error('Failed to load periods', err)
+    console.error('Failed to test DB', err)
+    alert('Failed to test DB')
   }
+}
+
+onMounted(() => {
+  window.addEventListener('click', closeMenu)
+  refreshPeriods()
 })
 
 onBeforeUnmount(() => {
-  window.removeEventListener('keydown', handleKey)
+  window.removeEventListener('click', closeMenu)
 })
 </script>
 
@@ -190,6 +271,25 @@ onBeforeUnmount(() => {
 
 .calendar-grid td.clickable {
   cursor: pointer;
+}
+
+.context-menu {
+  position: absolute;
+  background: white;
+  border: 1px solid #ccc;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  z-index: 1000;
+}
+
+.context-menu li {
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+.context-menu li:hover {
+  background: #eee;
 }
 </style>
 


### PR DESCRIPTION
## Summary
- add SQLite table and REST endpoints for period start/end, including 7-day matching for end dates
- provide API to remove entries and clear all records
- add calendar context menu to add/remove start or end and controls to clear or inspect database

## Testing
- `cd period_predictor/backend && npm test`
- `cd ../web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e59fb1208325b944d769eff72059