### PR TITLE
Ensure end_date column exists in database

### DIFF
--- a/period_predictor/backend/index.js
+++ b/period_predictor/backend/index.js
@@ -56,6 +56,22 @@ db.serialize(() => {
       }
     }
   );
+  db.all('PRAGMA table_info(periods)', (err, columns) => {
+    if (err) {
+      logger.error('Failed to fetch periods table info:', err);
+      return;
+    }
+    const hasEndDate = columns.some((c) => c.name === 'end_date');
+    if (!hasEndDate) {
+      db.run('ALTER TABLE periods ADD COLUMN end_date TEXT', (alterErr) => {
+        if (alterErr) {
+          logger.error('Failed to add end_date column:', alterErr);
+        } else {
+          logger.info('Added end_date column to periods table');
+        }
+      });
+    }
+  });
 });
 
 // Fetch all period records


### PR DESCRIPTION
## Summary
- ensure backend adds missing `end_date` column if absent

## Testing
- `cd period_predictor/backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e6f816d08325af4e7364d0ae3aa2