### PR TITLE
Add GPT-based prediction module with caching and API endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 dist/
+__pycache__/
+*.pyc
+predictions.db

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,39 @@
+from dataclasses import asdict
+import datetime as dt
+import sqlite3
+
+from fastapi import FastAPI
+
+from .prediction import (
+    Cycle,
+    DB_PATH,
+    generate_prediction,
+    get_latest_prediction,
+)
+
+app = FastAPI()
+
+
+def _load_history() -> list[Cycle]:
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS cycles (start TEXT, end TEXT, notes TEXT)"
+    )
+    rows = conn.execute("SELECT start, end, notes FROM cycles ORDER BY start").fetchall()
+    conn.close()
+    history: list[Cycle] = []
+    for start, end, notes in rows:
+        history.append(
+            Cycle(start=dt.date.fromisoformat(start), end=dt.date.fromisoformat(end), notes=notes)
+        )
+    return history
+
+
+@app.get("/api/prediction")
+def prediction_endpoint():
+    pred = get_latest_prediction()
+    if pred:
+        return asdict(pred)
+    history = _load_history()
+    pred = generate_prediction(history)
+    return asdict(pred)

--- a/api/prediction.py
+++ b/api/prediction.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import datetime as dt
+import os
+import sqlite3
+import statistics
+from dataclasses import dataclass
+from typing import List, Optional
+
+from openai import OpenAI
+
+DB_PATH = os.environ.get("PREDICTION_DB", "predictions.db")
+
+
+@dataclass
+class Cycle:
+    start: dt.date
+    end: dt.date
+    notes: Optional[str] = None
+
+    @property
+    def length(self) -> int:
+        return (self.end - self.start).days
+
+
+@dataclass
+class Prediction:
+    text: str
+    created_at: dt.datetime
+
+
+def _get_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS predictions (id INTEGER PRIMARY KEY AUTOINCREMENT, text TEXT, created_at TEXT)"
+    )
+    return conn
+
+
+def _summarize_history(history: List[Cycle]) -> str:
+    if not history:
+        return "No cycle history provided."
+    lengths = [c.length for c in history]
+    avg = statistics.mean(lengths)
+    var = statistics.pvariance(lengths) if len(lengths) > 1 else 0.0
+    recent_notes = "; ".join(filter(None, (c.notes for c in history[-3:] if c.notes)))
+    return (
+        f"Average cycle length: {avg:.1f} days\n"
+        f"Variance: {var:.2f}\n"
+        f"Recent notes: {recent_notes or 'None'}"
+    )
+
+
+def generate_prediction(history: List[Cycle]) -> Prediction:
+    client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+    prompt = _summarize_history(history) + "\nPredict the next menstrual cycle."
+    try:
+        response = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        text = response.choices[0].message.content.strip()
+    except Exception:
+        if history:
+            avg = statistics.mean(c.length for c in history)
+            next_start = history[-1].start + dt.timedelta(days=round(avg))
+            text = (
+                f"Based on historical average ({avg:.1f} days), next cycle around "
+                f"{next_start.isoformat()}."
+            )
+        else:
+            text = "Insufficient data for prediction."
+    pred = Prediction(text=text, created_at=dt.datetime.utcnow())
+    conn = _get_db()
+    conn.execute(
+        "INSERT INTO predictions(text, created_at) VALUES (?, ?)",
+        (pred.text, pred.created_at.isoformat()),
+    )
+    conn.commit()
+    conn.close()
+    return pred
+
+
+def get_latest_prediction(stale_hours: int = 24) -> Optional[Prediction]:
+    conn = _get_db()
+    row = conn.execute(
+        "SELECT text, created_at FROM predictions ORDER BY created_at DESC LIMIT 1"
+    ).fetchone()
+    conn.close()
+    if not row:
+        return None
+    text, created_at = row
+    created_at_dt = dt.datetime.fromisoformat(created_at)
+    if dt.datetime.utcnow() - created_at_dt > dt.timedelta(hours=stale_hours):
+        return None
+    return Prediction(text=text, created_at=created_at_dt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+openai>=1.0.0
+fastapi
+uvicorn
+pytest
+pytest-mock

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -1,0 +1,58 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import datetime as dt
+from fastapi.testclient import TestClient
+
+from api.app import app
+from api.prediction import Cycle, generate_prediction, _get_db
+
+
+def setup_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    monkeypatch.setenv("PREDICTION_DB", str(db_path))
+    return db_path
+
+
+def test_generate_prediction_uses_openai(mocker, tmp_path, monkeypatch):
+    setup_db(tmp_path, monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    mock_client = mocker.Mock()
+    mock_choice = mocker.Mock()
+    mock_choice.message.content = "GPT prediction"
+    mock_response = mocker.Mock(choices=[mock_choice])
+    mock_client.chat.completions.create.return_value = mock_response
+    mocker.patch("api.prediction.OpenAI", return_value=mock_client)
+
+    history = [Cycle(start=dt.date(2024, 1, 1), end=dt.date(2024, 1, 29), notes="ok")]
+    pred = generate_prediction(history)
+    assert pred.text == "GPT prediction"
+
+
+def test_generate_prediction_fallback(mocker, tmp_path, monkeypatch):
+    setup_db(tmp_path, monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    mock_client = mocker.Mock()
+    mock_client.chat.completions.create.side_effect = Exception("boom")
+    mocker.patch("api.prediction.OpenAI", return_value=mock_client)
+
+    history = [Cycle(start=dt.date(2024, 1, 1), end=dt.date(2024, 1, 29))]
+    pred = generate_prediction(history)
+    assert "Based on historical average" in pred.text
+
+
+def test_prediction_endpoint_uses_cache(tmp_path, monkeypatch):
+    db_path = setup_db(tmp_path, monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    conn = _get_db()
+    conn.execute(
+        "INSERT INTO predictions(text, created_at) VALUES (?, ?)",
+        ("cached", dt.datetime.utcnow().isoformat()),
+    )
+    conn.commit()
+    conn.close()
+
+    client = TestClient(app)
+    res = client.get("/api/prediction")
+    assert res.status_code == 200
+    assert res.json()["text"] == "cached"


### PR DESCRIPTION
## Summary
- add OpenAI dependency and prediction module that caches GPT results
- expose `/api/prediction` to return latest cached prediction or trigger a new one
- test OpenAI calls, fallback logic and endpoint caching with mocked responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9eca9d4ec83259be591e8cce505a7