### PR TITLE
feat: add prediction button and openai configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ The backend now runs on [Express](https://expressjs.com/) with a small Vue-based
 
 Logs from the add-on appear in Home Assistant's add-on log panel. Set the verbosity by adjusting the `log_level` option in the add-on configuration (`debug`, `info`, `warning`, or `error`).
 
+## Configuration
+
+In your add-on configuration you can set:
+
+- `log_level`: Controls log verbosity.
+- `openai_api_key`: Your OpenAI API key used for generating predictions.
+
 ## Add this repository to Home Assistant
 
 1. Go to **Settings → Add-ons → Add-on Store**.

--- a/period_predictor/config.yaml
+++ b/period_predictor/config.yaml
@@ -19,5 +19,7 @@ map:
   - data:rw
 options:
   log_level: info
+  openai_api_key: ""
 schema:
   log_level: list(debug|info|warning|error)
+  openai_api_key: str?

--- a/period_predictor/rootfs/etc/services.d/period-predictor/run
+++ b/period_predictor/rootfs/etc/services.d/period-predictor/run
@@ -18,4 +18,12 @@ LOG_LEVEL="$(bashio::config 'log_level' 'info')"
 export LOG_LEVEL
 bashio::log.info "Using log level ${LOG_LEVEL}"
 
+OPENAI_API_KEY="$(bashio::config 'openai_api_key' '')"
+if bashio::var.has_value "${OPENAI_API_KEY}"; then
+    export OPENAI_API_KEY
+    bashio::log.info "OpenAI API key loaded from configuration"
+else
+    bashio::log.info "No OpenAI API key provided"
+fi
+
 exec npm --prefix /app/backend start

--- a/period_predictor/web/src/components/SidebarCalendar.vue
+++ b/period_predictor/web/src/components/SidebarCalendar.vue
@@ -41,6 +41,9 @@
       <button @click="testDb" aria-label="Test database" tabindex="2">
         Test database
       </button>
+      <button @click="predictNext" aria-label="Predict next period" tabindex="3">
+        Predict next period
+      </button>
     </div>
     <ul
       v-if="menu.visible"
@@ -238,6 +241,22 @@ async function testDb() {
   } catch (err) {
     console.error('Failed to test DB', err)
     alert('Failed to test DB')
+  }
+}
+
+async function predictNext() {
+  try {
+    const res = await fetch('api/prediction')
+    if (!res.ok) throw new Error('Request failed')
+    const data = await res.json()
+    if (data.next) {
+      alert(`Next period expected on ${data.next}`)
+    } else {
+      alert('Not enough data for prediction')
+    }
+  } catch (err) {
+    console.error('Failed to fetch prediction', err)
+    alert('Failed to fetch prediction')
   }
 }
 


### PR DESCRIPTION
## Summary
- add OpenAI API key option to add-on configuration
- expose OpenAI key to backend and document configuration
- add UI button to fetch next period prediction

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm --prefix period_predictor/backend test`
- `npm --prefix period_predictor/web test`


------
https://chatgpt.com/codex/tasks/task_e_68b9ee1ca4b083259e242d9bcb483208