### PR TITLE
Add PMS window and cycle details to predictions

### DIFF
--- a/api/prediction.py
+++ b/api/prediction.py
@@ -27,12 +27,28 @@ class Cycle:
 class Prediction:
     text: str
     created_at: dt.datetime
+    cycle_length: int
+    next_start: dt.date
+    pms_start: dt.date
+    pms_end: dt.date
+    period_length: int
 
 
 def _get_db() -> sqlite3.Connection:
     conn = sqlite3.connect(DB_PATH)
     conn.execute(
-        "CREATE TABLE IF NOT EXISTS predictions (id INTEGER PRIMARY KEY AUTOINCREMENT, text TEXT, created_at TEXT)"
+        (
+            "CREATE TABLE IF NOT EXISTS predictions ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "text TEXT, "
+            "created_at TEXT, "
+            "cycle_length INTEGER, "
+            "next_start TEXT, "
+            "pms_start TEXT, "
+            "pms_end TEXT, "
+            "period_length INTEGER"
+            ")"
+        )
     )
     return conn
 
@@ -52,6 +68,23 @@ def _summarize_history(history: List[Cycle]) -> str:
 
 
 def generate_prediction(history: List[Cycle]) -> Prediction:
+    # Estimate cycle length
+    if history:
+        lengths = [c.length for c in history]
+        cycle_length = round(statistics.mean(lengths))
+        last_start = history[-1].start
+    else:
+        cycle_length = 28
+        last_start = dt.date.today()
+    next_start = last_start + dt.timedelta(days=cycle_length)
+
+    # PMS window approximately 7 to 5 days before period
+    pms_start = next_start - dt.timedelta(days=7)
+    pms_end = next_start - dt.timedelta(days=5)
+
+    # Expected period length (simple default)
+    period_length = 5
+
     client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
     prompt = _summarize_history(history) + "\nPredict the next menstrual cycle."
     try:
@@ -62,19 +95,36 @@ def generate_prediction(history: List[Cycle]) -> Prediction:
         text = response.choices[0].message.content.strip()
     except Exception:
         if history:
-            avg = statistics.mean(c.length for c in history)
-            next_start = history[-1].start + dt.timedelta(days=round(avg))
             text = (
-                f"Based on historical average ({avg:.1f} days), next cycle around "
+                f"Based on historical average ({cycle_length} days), next cycle around "
                 f"{next_start.isoformat()}."
             )
         else:
             text = "Insufficient data for prediction."
-    pred = Prediction(text=text, created_at=dt.datetime.utcnow())
+
+    pred = Prediction(
+        text=text,
+        created_at=dt.datetime.utcnow(),
+        cycle_length=cycle_length,
+        next_start=next_start,
+        pms_start=pms_start,
+        pms_end=pms_end,
+        period_length=period_length,
+    )
+
     conn = _get_db()
     conn.execute(
-        "INSERT INTO predictions(text, created_at) VALUES (?, ?)",
-        (pred.text, pred.created_at.isoformat()),
+        "INSERT INTO predictions(text, created_at, cycle_length, next_start, pms_start, pms_end, period_length) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            pred.text,
+            pred.created_at.isoformat(),
+            pred.cycle_length,
+            pred.next_start.isoformat(),
+            pred.pms_start.isoformat(),
+            pred.pms_end.isoformat(),
+            pred.period_length,
+        ),
     )
     conn.commit()
     conn.close()
@@ -84,13 +134,22 @@ def generate_prediction(history: List[Cycle]) -> Prediction:
 def get_latest_prediction(stale_hours: int = 24) -> Optional[Prediction]:
     conn = _get_db()
     row = conn.execute(
-        "SELECT text, created_at FROM predictions ORDER BY created_at DESC LIMIT 1"
+        "SELECT text, created_at, cycle_length, next_start, pms_start, pms_end, period_length "
+        "FROM predictions ORDER BY created_at DESC LIMIT 1"
     ).fetchone()
     conn.close()
     if not row:
         return None
-    text, created_at = row
+    text, created_at, cycle_length, next_start, pms_start, pms_end, period_length = row
     created_at_dt = dt.datetime.fromisoformat(created_at)
     if dt.datetime.utcnow() - created_at_dt > dt.timedelta(hours=stale_hours):
         return None
-    return Prediction(text=text, created_at=created_at_dt)
+    return Prediction(
+        text=text,
+        created_at=created_at_dt,
+        cycle_length=cycle_length,
+        next_start=dt.date.fromisoformat(next_start),
+        pms_start=dt.date.fromisoformat(pms_start),
+        pms_end=dt.date.fromisoformat(pms_end),
+        period_length=period_length,
+    )

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -14,6 +14,31 @@ def setup_db(tmp_path, monkeypatch):
     return db_path
 
 
+def _compute_events(periods, prediction):
+    events = {}
+    for p in periods:
+        start = dt.date.fromisoformat(p["start_date"])
+        end = dt.date.fromisoformat(p["end_date"]) if p["end_date"] else start
+        d = start
+        while d <= end:
+            events[d.isoformat()] = "start" if d == start else "period"
+            d += dt.timedelta(days=1)
+    if prediction:
+        start = dt.date.fromisoformat(prediction["next_start"])
+        for i in range(prediction["period_length"]):
+            day = start + dt.timedelta(days=i)
+            key = day.isoformat()
+            events.setdefault(key, "prediction-start" if i == 0 else "prediction")
+        pms_start = dt.date.fromisoformat(prediction["pms_start"])
+        pms_end = dt.date.fromisoformat(prediction["pms_end"])
+        d = pms_start
+        while d <= pms_end:
+            key = d.isoformat()
+            events.setdefault(key, "pms")
+            d += dt.timedelta(days=1)
+    return events
+
+
 def test_generate_prediction_uses_openai(mocker, tmp_path, monkeypatch):
     setup_db(tmp_path, monkeypatch)
     monkeypatch.setenv("OPENAI_API_KEY", "test")
@@ -27,6 +52,11 @@ def test_generate_prediction_uses_openai(mocker, tmp_path, monkeypatch):
     history = [Cycle(start=dt.date(2024, 1, 1), end=dt.date(2024, 1, 29), notes="ok")]
     pred = generate_prediction(history)
     assert pred.text == "GPT prediction"
+    assert pred.cycle_length == 28
+    assert pred.next_start == dt.date(2024, 1, 29)
+    assert pred.pms_start == dt.date(2024, 1, 22)
+    assert pred.pms_end == dt.date(2024, 1, 24)
+    assert pred.period_length == 5
 
 
 def test_generate_prediction_fallback(mocker, tmp_path, monkeypatch):
@@ -39,6 +69,8 @@ def test_generate_prediction_fallback(mocker, tmp_path, monkeypatch):
     history = [Cycle(start=dt.date(2024, 1, 1), end=dt.date(2024, 1, 29))]
     pred = generate_prediction(history)
     assert "Based on historical average" in pred.text
+    assert pred.next_start == dt.date(2024, 1, 29)
+    assert pred.period_length == 5
 
 
 def test_prediction_endpoint_uses_cache(tmp_path, monkeypatch):
@@ -46,8 +78,16 @@ def test_prediction_endpoint_uses_cache(tmp_path, monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "test")
     conn = _get_db()
     conn.execute(
-        "INSERT INTO predictions(text, created_at) VALUES (?, ?)",
-        ("cached", dt.datetime.utcnow().isoformat()),
+        "INSERT INTO predictions(text, created_at, cycle_length, next_start, pms_start, pms_end, period_length) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "cached",
+            dt.datetime.utcnow().isoformat(),
+            28,
+            dt.date(2024, 1, 29).isoformat(),
+            dt.date(2024, 1, 22).isoformat(),
+            dt.date(2024, 1, 24).isoformat(),
+            5,
+        ),
     )
     conn.commit()
     conn.close()
@@ -55,4 +95,34 @@ def test_prediction_endpoint_uses_cache(tmp_path, monkeypatch):
     client = TestClient(app)
     res = client.get("/api/prediction")
     assert res.status_code == 200
-    assert res.json()["text"] == "cached"
+    data = res.json()
+    assert data["text"] == "cached"
+    assert data["pms_start"] == "2024-01-22"
+
+
+def test_pms_days_do_not_overlap():
+    periods = [{"start_date": "2024-01-01", "end_date": "2024-01-05"}]
+    prediction = {
+        "next_start": "2024-01-10",
+        "period_length": 5,
+        "pms_start": "2024-01-02",
+        "pms_end": "2024-01-04",
+    }
+    events = _compute_events(periods, prediction)
+    # PMS window overlaps recorded period; existing period days should remain
+    assert events["2024-01-02"] == "period"
+    assert events["2024-01-03"] == "period"
+
+
+def test_prediction_events_alignment():
+    periods = []
+    prediction = {
+        "next_start": "2024-02-01",
+        "period_length": 5,
+        "pms_start": "2024-01-25",
+        "pms_end": "2024-01-27",
+    }
+    events = _compute_events(periods, prediction)
+    assert events["2024-02-01"] == "prediction-start"
+    assert events["2024-02-03"] == "prediction"
+    assert events["2024-01-26"] == "pms"


### PR DESCRIPTION
## Summary
- extend backend predictions with cycle length, PMS window, and period duration
- store new prediction fields in database
- highlight PMS/predicted days and show summary in calendar UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9ef6b01008325a2b878342ad89484