### PR TITLE
Use GPT for period predictions

### DIFF
--- a/period_predictor/backend/package.json
+++ b/period_predictor/backend/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "sqlite3": "^5.1.6"
+    "sqlite3": "^5.1.6",
+    "openai": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Integrate OpenAI GPT-based prediction into Node backend with fallback heuristic
- Add OpenAI dependency for backend service

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba077a578483258754fefd1d3e02e1