### PR TITLE
Add Home Assistant events for period predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ In your add-on configuration you can set:
 - `log_level`: Controls log verbosity.
 - `openai_api_key`: Your OpenAI API key used for generating predictions.
 
+## Events
+
+The add-on emits Home Assistant events that can be used in automations or
+flows (e.g. Node-RED):
+
+- `period_predictor_pms_start` – fired on the predicted PMS start date.
+- `period_predictor_period_start_predicted` – fired on the predicted period
+  start date.
+- `period_predictor_period_start` – fired when a period start is recorded via
+  the API.
+
+Each event includes the `user` and `date` in its data payload.
+
 ## Add this repository to Home Assistant
 
 1. Go to **Settings → Add-ons → Add-on Store**.

--- a/period_predictor/backend/index.js
+++ b/period_predictor/backend/index.js
@@ -10,6 +10,33 @@ const SUPERVISOR_TOKEN =
   process.env.SUPERVISOR_TOKEN || process.env.HASSIO_TOKEN || '';
 const HA_API = 'http://supervisor/homeassistant/api';
 
+/**
+ * Fire an event on Home Assistant's event bus. If the supervisor token is not
+ * available (for example during local development) the function simply logs
+ * the attempt.
+ * @param {string} eventType
+ * @param {object} data
+ */
+async function fireEvent(eventType, data = {}) {
+  if (!SUPERVISOR_TOKEN) {
+    logger.warn(`Unable to fire ${eventType}; supervisor token not set`);
+    return;
+  }
+  try {
+    await fetch(`${HA_API}/events/${eventType}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${SUPERVISOR_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    });
+    logger.info(`Fired Home Assistant event ${eventType}`);
+  } catch (err) {
+    logger.error(`Failed to fire event ${eventType}:`, err);
+  }
+}
+
 const app = express();
 const PORT = process.env.PORT || 3002;
 
@@ -92,6 +119,73 @@ db.serialize(() => {
   });
 });
 
+async function generatePrediction(rows) {
+  let nextDate;
+  let message = '';
+
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  try {
+    const dates = rows.map((r) => r.start_date).join(', ');
+    const prompt =
+      rows.length > 0
+        ? `Given the recorded menstrual cycle start dates: ${dates}. Predict the next start date and provide a short encouraging message. Respond with JSON {"next_start":"YYYY-MM-DD","message":"text"}.`
+        : `No prior period data is available. Assume a 28 day cycle starting today ${new Date()
+            .toISOString()
+            .split('T')[0]}. Respond with JSON {"next_start":"YYYY-MM-DD","message":"text"}.`;
+    const response = await client.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: prompt }],
+    });
+    const content = response.choices[0].message.content;
+    const parsed = JSON.parse(content);
+    nextDate = new Date(parsed.next_start);
+    message = parsed.message;
+    logger.info(`Predicted next period start ${parsed.next_start} using GPT`);
+  } catch (gptErr) {
+    logger.error('GPT prediction failed, falling back:', gptErr);
+    let cycleLength = 28; // default cycle length
+    if (rows.length >= 2) {
+      const dates = rows.map((r) => new Date(r.start_date));
+      const intervals = [];
+      for (let i = 1; i < dates.length; i++) {
+        const diffMs = dates[i] - dates[i - 1];
+        intervals.push(diffMs / (1000 * 60 * 60 * 24));
+      }
+      cycleLength = intervals.reduce((a, b) => a + b, 0) / intervals.length;
+      nextDate = new Date(
+        dates[dates.length - 1].getTime() + cycleLength * 24 * 60 * 60 * 1000
+      );
+      logger.info(
+        `Predicted next period start ${nextDate.toISOString().split('T')[0]} based on history`
+      );
+    } else if (rows.length === 1) {
+      const lastStart = new Date(rows[0].start_date);
+      nextDate = new Date(
+        lastStart.getTime() + cycleLength * 24 * 60 * 60 * 1000
+      );
+      logger.info('Only one period record; using default 28 day cycle');
+    } else {
+      nextDate = new Date();
+      nextDate.setDate(nextDate.getDate() + cycleLength);
+      logger.info('No period data; using today + 28 days for prediction');
+    }
+    message = `Based on historical average, next period around ${nextDate
+      .toISOString()
+      .split('T')[0]}.`;
+  }
+
+  const pmsStart = new Date(nextDate.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const pmsEnd = new Date(nextDate.getTime() - 5 * 24 * 60 * 60 * 1000);
+
+  return {
+    next_start: nextDate.toISOString().split('T')[0],
+    period_length: 5,
+    pms_start: pmsStart.toISOString().split('T')[0],
+    pms_end: pmsEnd.toISOString().split('T')[0],
+    text: message,
+  };
+}
+
 // Proxy Home Assistant users
 app.get('/api/users', async (_req, res) => {
   if (!SUPERVISOR_TOKEN) {
@@ -148,6 +242,7 @@ app.post('/api/periods/start', (req, res) => {
         return res.status(500).json({ error: err.message });
       }
       logger.info(`Recorded period start date ${date} for ${user}`);
+      fireEvent('period_predictor_period_start', { user, date });
       res.status(201).json({});
     }
   );
@@ -272,76 +367,58 @@ app.get('/api/prediction', (req, res) => {
         logger.error('Failed to generate prediction:', err);
         return res.status(500).json({ error: err.message });
       }
-
-    let nextDate;
-    let message = '';
-
-    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
-    try {
-      const dates = rows.map((r) => r.start_date).join(', ');
-      const prompt =
-        rows.length > 0
-          ? `Given the recorded menstrual cycle start dates: ${dates}. Predict the next start date and provide a short encouraging message. Respond with JSON {"next_start":"YYYY-MM-DD","message":"text"}.`
-          : `No prior period data is available. Assume a 28 day cycle starting today ${new Date()
-              .toISOString()
-              .split('T')[0]}. Respond with JSON {"next_start":"YYYY-MM-DD","message":"text"}.`;
-      const response = await client.chat.completions.create({
-        model: 'gpt-4o-mini',
-        messages: [{ role: 'user', content: prompt }],
-      });
-      const content = response.choices[0].message.content;
-      const parsed = JSON.parse(content);
-      nextDate = new Date(parsed.next_start);
-      message = parsed.message;
-      logger.info(`Predicted next period start ${parsed.next_start} using GPT`);
-    } catch (gptErr) {
-      logger.error('GPT prediction failed, falling back:', gptErr);
-      let cycleLength = 28; // default cycle length
-      if (rows.length >= 2) {
-        const dates = rows.map((r) => new Date(r.start_date));
-        const intervals = [];
-        for (let i = 1; i < dates.length; i++) {
-          const diffMs = dates[i] - dates[i - 1];
-          intervals.push(diffMs / (1000 * 60 * 60 * 24));
-        }
-        cycleLength = intervals.reduce((a, b) => a + b, 0) / intervals.length;
-        nextDate = new Date(
-          dates[dates.length - 1].getTime() + cycleLength * 24 * 60 * 60 * 1000
-        );
-        logger.info(
-          `Predicted next period start ${nextDate.toISOString().split('T')[0]} based on history`
-        );
-      } else if (rows.length === 1) {
-        const lastStart = new Date(rows[0].start_date);
-        nextDate = new Date(
-          lastStart.getTime() + cycleLength * 24 * 60 * 60 * 1000
-        );
-        logger.info('Only one period record; using default 28 day cycle');
-      } else {
-        nextDate = new Date();
-        nextDate.setDate(nextDate.getDate() + cycleLength);
-        logger.info('No period data; using today + 28 days for prediction');
+      try {
+        const prediction = await generatePrediction(rows);
+        res.json(prediction);
+      } catch (e) {
+        logger.error('Prediction generation failed:', e);
+        res.status(500).json({ error: 'prediction failed' });
       }
-      message = `Based on historical average, next period around ${nextDate
-        .toISOString()
-        .split('T')[0]}.`;
     }
+  );
+});
 
-    const pmsStart = new Date(nextDate.getTime() - 7 * 24 * 60 * 60 * 1000);
-    const pmsEnd = new Date(nextDate.getTime() - 5 * 24 * 60 * 60 * 1000);
-
-    res.json({
-      next_start: nextDate.toISOString().split('T')[0],
-      period_length: 5,
-      pms_start: pmsStart.toISOString().split('T')[0],
-      pms_end: pmsEnd.toISOString().split('T')[0],
-      text: message,
+function checkDailyEvents() {
+  const today = new Date().toISOString().split('T')[0];
+  db.all('SELECT DISTINCT user FROM periods', [], (err, rows) => {
+    if (err) {
+      logger.error('Failed to load users for daily event check:', err);
+      return;
+    }
+    const users = rows.length ? rows.map((r) => r.user) : ['default'];
+    users.forEach((user) => {
+      db.all(
+        'SELECT start_date FROM periods WHERE user = ? ORDER BY start_date',
+        [user],
+        async (err2, periods) => {
+          if (err2) {
+            logger.error('Failed to load periods for event check:', err2);
+            return;
+          }
+          try {
+            const prediction = await generatePrediction(periods);
+            if (prediction.pms_start === today) {
+              fireEvent('period_predictor_pms_start', { user, date: today });
+            }
+            if (prediction.next_start === today) {
+              fireEvent('period_predictor_period_start_predicted', {
+                user,
+                date: today,
+              });
+            }
+          } catch (e) {
+            logger.error('Failed to compute prediction for events:', e);
+          }
+        }
+      );
     });
   });
-});
+}
 
 // Start server
 app.listen(PORT, () => {
   logger.info(`Backend server listening on port ${PORT}`);
+  checkDailyEvents();
+  setInterval(checkDailyEvents, 24 * 60 * 60 * 1000);
 });
 


### PR DESCRIPTION
## Summary
- fire Home Assistant events when a period start is recorded
- emit predicted PMS and period start events on the appropriate days
- document new event types for automations

## Testing
- `npm --prefix period_predictor/backend test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baf8a4c9748325849461fd338b1dbb